### PR TITLE
Ensure power is always int

### DIFF
--- a/lib/Device.ts
+++ b/lib/Device.ts
@@ -118,16 +118,16 @@ class Device {
      */
     setLastPower(watts: number, minPower?: number, maxPower?: number) {
         let powerInfo: PowerInfoType = {
-            AveragePower: watts,
+            AveragePower: Math.round(watts),
             Timestamp: 0,
             AveragingInterval: 60
         };
 
         if (maxPower) {
-            powerInfo.MaxPower = maxPower
+            powerInfo.MaxPower = Math.round(maxPower);
         }
         if (minPower) {
-            powerInfo.MinPower = minPower;
+            powerInfo.MinPower = Math.round(minPower);
         }
 
         this.deviceStatus.PowerConsumption = {

--- a/lib/SEMPServer.ts
+++ b/lib/SEMPServer.ts
@@ -48,7 +48,9 @@ class SEMPServer {
         this.app.get('/semp/', (req, res) => {
             console.log("Requested all devices. " + req.url);
             console.log(JSON.stringify(req.query));
-            let devices: Device2EM = SEMPServer.convertDevices(this.gateway.getAllDevices());
+            let deviceList = this.gateway.getAllDevices()
+            let devices: Device2EM = SEMPServer.convertDevices(deviceList);
+            // console.log(JSON.stringify(deviceList));
             res.send(SEMPServer.convertJSToXML(devices))
         });
 

--- a/lib/api/Api.ts
+++ b/lib/api/Api.ts
@@ -48,6 +48,7 @@ class Api {
                     b.emSignalsAccepted, b.status, b.vendor, b.serialNr, b.absoluteTimestamps, b.optionalEnergy, b.minOnTime,
                     b.minOffTime, b.url);
                 this.gateway.setDevice(b.deviceId, d);
+                console.log("Added device " + b.deviceId);
                 res.json(util.createResponse(200, "OK"))
             } catch (e) {
                 res.status(400);


### PR DESCRIPTION
The spec requires power (in Watts) to be of type `int`. My source was supplying float values and this seemed like a fine way to ensure compatibility with the spec.