### PR TITLE
use workdir to unbreak build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM node
+WORKDIR /semp
 COPY package*.json ./
 RUN npm install
 COPY . .


### PR DESCRIPTION
`lib` conflicted with existing directory, which meant `COPY . .` didn't succeed.
This used to work but I imagine something changed about the `node` base image. I didn't dig deeper as this seems like a good practice in any case.